### PR TITLE
Use instance public ip instead of private ones

### DIFF
--- a/lib/capistrano/autoscale/aws/instance.rb
+++ b/lib/capistrano/autoscale/aws/instance.rb
@@ -6,11 +6,11 @@ module Capistrano
       class Instance < Base
         STATE_RUNNING = 16
 
-        attr_reader :aws_counterpart, :id, :private_ip, :state
+        attr_reader :aws_counterpart, :id, :public_ip, :state
 
-        def initialize(id, private_ip, state)
+        def initialize(id, public_ip, state)
           @id = id
-          @private_ip = private_ip
+          @public_ip = public_ip
           @state = state
           @aws_counterpart = ::Aws::EC2::Instance.new id, client: ec2_client
         end

--- a/lib/capistrano/autoscale/aws/instance_collection.rb
+++ b/lib/capistrano/autoscale/aws/instance_collection.rb
@@ -10,7 +10,7 @@ module Capistrano
 
         def initialize(ids)
           @instances = query_instances_by_ids(ids).map do |i|
-            Instance.new(i.instance_id, i.private_ip_address, i.state.code)
+            Instance.new(i.instance_id, i.public_ip_address, i.state.code)
           end
         end
 

--- a/lib/capistrano/autoscale/dsl.rb
+++ b/lib/capistrano/autoscale/dsl.rb
@@ -15,7 +15,7 @@ module Capistrano
         info "Auto Scaling Group: #{groupname}"
 
         instances.each.with_index do |instance, index|
-          info "Adding server #{instance.private_ip}"
+          info "Adding server #{instance.public_ip}"
 
           if index.zero? && properties.key?(:primary_roles)
             server_properties = properties.dup
@@ -24,7 +24,7 @@ module Capistrano
             server_properties = properties
           end
 
-          server(instance.private_ip, server_properties)
+          server(instance.public_ip, server_properties)
         end
 
         instances = asg.instances_in_service.running

--- a/spec/capistrano/autoscale/aws/instance_collection_spec.rb
+++ b/spec/capistrano/autoscale/aws/instance_collection_spec.rb
@@ -18,11 +18,11 @@ describe Capistrano::Autoscale::AWS::InstanceCollection do
       describe '#instances' do
         it 'returns Instance objects with name/hostname/state' do
           expect(subject.instances[0].id).to eq 'i-1234567890'
-          expect(subject.instances[0].private_ip).to eq '10.0.0.12'
+          expect(subject.instances[0].public_ip).to eq '10.0.0.12'
           expect(subject.instances[0].state).to eq 16
 
           expect(subject.instances[1].id).to eq 'i-500'
-          expect(subject.instances[1].private_ip).to eq '10.0.0.12'
+          expect(subject.instances[1].public_ip).to eq '10.0.0.12'
           expect(subject.instances[1].state).to eq 32
         end
       end

--- a/spec/capistrano/autoscale/aws/instance_spec.rb
+++ b/spec/capistrano/autoscale/aws/instance_spec.rb
@@ -10,9 +10,9 @@ describe Capistrano::Autoscale::AWS::Instance do
     end
   end
 
-  describe '#private_ip' do
+  describe '#public_ip' do
     it 'returns the private IP address' do
-      expect(subject.private_ip).to eq '10.0.0.1'
+      expect(subject.public_ip).to eq '10.0.0.1'
     end
   end
 


### PR DESCRIPTION
- What? Use instance public ip instead of private ones
- Why? For internal deployment constraints
- How? Change private_ip to public_ip